### PR TITLE
Fix C++ compression utilities

### DIFF
--- a/c++/compress.cpp
+++ b/c++/compress.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <fstream>
 #include <cstdint>
+#include <string>
 
 // Conditionally include the filesystem header based on C++ version support
 #if __cplusplus < 201703L
@@ -51,8 +52,8 @@ void compress(const std::string& inputFilename, const std::string& outputFilenam
             count++;
         } else {
             // If the sequence ends, write the count and byte to the output file
-            outfile.write(reinterpret_cast<char*>(&count), 2); // Write the 2-byte count
-            outfile.write(reinterpret_cast<char*>(&previousByte), 1); // Write the repeated byte
+            outfile.write(reinterpret_cast<char*>(&count), sizeof(count)); // Write the count
+            outfile.write(reinterpret_cast<char*>(&previousByte), sizeof(previousByte)); // Write the repeated byte
             if (!outfile) {
                 std::cerr << "An error occurred while writing compressed data to the output file\n";
                 return;
@@ -64,8 +65,8 @@ void compress(const std::string& inputFilename, const std::string& outputFilenam
     }
 
     // Write the final byte sequence to the output file after the loop ends
-    outfile.write(reinterpret_cast<char*>(&count), 2);
-    outfile.write(reinterpret_cast<char*>(&previousByte), 1);
+    outfile.write(reinterpret_cast<char*>(&count), sizeof(count));
+    outfile.write(reinterpret_cast<char*>(&previousByte), sizeof(previousByte));
 }
 
 // Function to decompress a file compressed with the run-length encoding algorithm
@@ -88,10 +89,10 @@ void decompress(const std::string& inputFilename, const std::string& outputFilen
     uint8_t byte;   // Variable to store the byte to be repeated
 
     // Loop through the input file, reading count and byte pairs
-    while (infile.read(reinterpret_cast<char*>(&count), 2) && infile.read(reinterpret_cast<char*>(&byte), 1)) {
+    while (infile.read(reinterpret_cast<char*>(&count), sizeof(count)) && infile.read(reinterpret_cast<char*>(&byte), sizeof(byte))) {
         // Write the byte to the output file 'count' times
         for (uint16_t i = 0; i < count; ++i) {
-            outfile.write(reinterpret_cast<char*>(&byte), 1);
+            outfile.write(reinterpret_cast<char*>(&byte), sizeof(byte));
             if (!outfile) {
                 std::cerr << "An error occurred while writing decompressed data to the output file\n";
                 return;

--- a/c++/decompress.cpp
+++ b/c++/decompress.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <fstream>
 #include <cstdint>
+#include <string>
 
 void decompress(const std::string& inputFilename, const std::string& outputFilename) {
     // Open the input file in binary read mode
@@ -21,10 +22,10 @@ void decompress(const std::string& inputFilename, const std::string& outputFilen
     uint8_t byte;
 
     // Read count and byte pairs from the input file
-    while (infile.read(reinterpret_cast<char*>(&count), 2) && infile.read(reinterpret_cast<char*>(&byte), 1)) {
+    while (infile.read(reinterpret_cast<char*>(&count), sizeof(count)) && infile.read(reinterpret_cast<char*>(&byte), sizeof(byte))) {
         for (uint16_t i = 0; i < count; ++i) {
             // Write the byte 'count' times to the output file
-            outfile.write(reinterpret_cast<char*>(&byte), 1);
+            outfile.write(reinterpret_cast<char*>(&byte), sizeof(byte));
             if (!outfile) {
                 std::cerr << "Error writing to output file.\n";
                 return;

--- a/hello_world.py
+++ b/hello_world.py
@@ -1,1 +1,1 @@
-Print('Hello, World!')
+print('Hello, World!')


### PR DESCRIPTION
## Summary
- fix compile error in hello_world example
- include `<string>` in RLE tools
- use `sizeof` for read/write operations in compress/decompress

## Testing
- `g++ c++/compress.cpp -o c++/compress -std=c++17`
- `g++ c++/decompress.cpp -o c++/decompress -std=c++17`
- `./c++/compress --compress c++/sample.txt c++/sample.rle`
- `./c++/compress --decompress c++/sample.rle c++/sample_out.txt`
- `./c++/decompress c++/sample.rle c++/sample_out2.txt`


------
https://chatgpt.com/codex/tasks/task_e_683f602ae244832cbfee76bfdbef549b